### PR TITLE
Add polyfills to support old browsers

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -18,6 +18,7 @@
     "node-forge": "^0.9.1",
     "pixelmatch": "^5.2.1",
     "react": "^16.13.1",
+    "react-app-polyfill": "^2.0.0",
     "react-dom": "^16.13.1",
     "react-flexbox-grid": "^2.1.2",
     "react-i18next": "^11.7.4",

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import React, { Suspense } from 'react';
 import './config/i18n';
 import ReactDOM from 'react-dom';

--- a/app/client/src/polyfills.tsx
+++ b/app/client/src/polyfills.tsx
@@ -4,4 +4,4 @@ import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 // probably is better to load polyfills on demand,
 // browser tests are required to detect which polyfills are needed
-import "core-js";
+import 'core-js';

--- a/app/client/src/polyfills.tsx
+++ b/app/client/src/polyfills.tsx
@@ -1,0 +1,6 @@
+// recommended by create-react-app
+import 'react-app-polyfill/ie9';
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+
+import "core-js";

--- a/app/client/src/polyfills.tsx
+++ b/app/client/src/polyfills.tsx
@@ -2,5 +2,6 @@
 import 'react-app-polyfill/ie9';
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
-
+// probably is better to load polyfills on demand,
+// browser tests are required to detect which polyfills are needed
 import "core-js";

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -3483,6 +3483,11 @@ core-js@^3.5.0:
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz#f51523668ac8a294d1285c3b9db44025fda66d47"
   integrity sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==
 
+core-js@^3.6.5:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"
+  integrity sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8911,7 +8916,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@^8.0.3:
+promise@^8.0.3, promise@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
   integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
@@ -9091,6 +9096,18 @@ react-app-polyfill@^1.0.6:
     raf "^3.4.1"
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
+
+react-app-polyfill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf"
+  integrity sha512-0sF4ny9v/B7s6aoehwze9vJNWcmCemAUYBVasscVr92+UYiEqDXOxfKjXN685mDaMRNF3WdhHQs76oTODMocFA==
+  dependencies:
+    core-js "^3.6.5"
+    object-assign "^4.1.1"
+    promise "^8.1.0"
+    raf "^3.4.1"
+    regenerator-runtime "^0.13.7"
+    whatwg-fetch "^3.4.1"
 
 react-dev-utils@^10.2.1:
   version "10.2.1"
@@ -9419,7 +9436,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
@@ -11259,7 +11276,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@^3.0.0:
+whatwg-fetch@^3.0.0, whatwg-fetch@^3.4.1:
   version "3.5.0"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
   integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==


### PR DESCRIPTION
After trying to open the client on Edge 18 and Chrome 53, I've detected some js errors related of missing newer API's.

According [create-react-app docs](https://github.com/facebook/create-react-app/tree/master/packages/react-app-polyfill), the developer must manually add the polyfills as needed. So I've added the recommended polyfills and [core-js polyfills](https://github.com/zloirock/core-js) (which are used to bring all new ecma features to old browsers).

It would hardly be necessary to use all these polyfills, but as we don't have cross - browser tests yet, and I am not so familiar with the codebase, I've used a catch-all strategy, importing whole code-js lib, this way solving a lot of hidden bugs related to newer API's in the code and related dependencies.

With this change I could open the client both in the Chrome 53 (on my TV) and in Edge 18 (on Xone, still no luck with WebRTC)

Related #90 