### PR TITLE
[+] Auto update Homebrew cask from GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,24 @@ jobs:
           file: ${{ matrix.artifact_name }}
           tags: true
           draft: true
+
+  homebrew-pr:
+    runs-on: macos-10.15
+    steps:
+      - name: Set $VERSION without preifx v
+        # https://github.community/t/how-to-get-just-the-tag-name/16241
+        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions
+        run: echo VERSION=$(echo ${GITHUB_REF##*/} | cut -c2-) >> $GITHUB_ENV
+
+      - name: Install Homebrew
+        # Command from https://brew.sh/
+        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      # https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask
+      - name: Updating cask Deskreen
+        run: brew bump-cask-pr --version $VERSION deskreen
+        env:
+          # First, create a personal access token: (url from Homebrew's output)
+          # https://github.com/settings/tokens/new?scopes=gist,public_repo&description=Homebrew
+          # Then, go repo settings -> Secrets -> New repository secret -> HOMEBREW_GITHUB_API_TOKEN : <secret value>.
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Thank you in advance!
 
 - Get the .dmg file from Releases
 
+- Or get from [Homebrew](https://brew.sh/): `brew install --cask deskreen`
+
 ### Linux
 
 - Debian and Ubuntu based distributions (deb)


### PR DESCRIPTION
@pavlobu 
I finished GitHub Action to auto-update the Deskreen cask.
It will auto-create PR to Homebrew-cask repo, like [homebrew-cask/pull/99386](https://github.com/Homebrew/homebrew-cask/pull/99386).
But please noticed comment at [.github/workflows/release.yml#L136](https://github.com/VergeDX/deskreen/blob/master/.github/workflows/release.yml#L136), you need to create a personal access token.