### PR TITLE
used the correct way for getting ci version

### DIFF
--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -32,11 +32,11 @@ jobs:
       AUR_PRIVATE_KEY : ${{ secrets.AUR_PRIVATE_KEY }}
       AUR_EMAIL : ${{ secrets.AUR_EMAIL }}
       AUR_NAME : ${{ secrets.AUR_NAME }}
-      VERSION : ${GITHUB_REF##*/}
     container: archlinux
     steps:
       - name: Update package database and packages
         run: |
+          export VERSION=${GITHUB_REF##*/}
           (patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && bsdtar -C / -xvf "$patched_glibc") &> /dev/null
           pacman --noconfirm -Syu
           pacman --noconfirm -S base-devel wget git


### PR DESCRIPTION
@pavlobu  there was a mistake in getting the version for ci for post-release
This is the corrected way of doing it,
