### PR TITLE
[U] Update comment of HOMEBREW_GITHUB_API_TOKEN's scope.

### DIFF
--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: brew bump-cask-pr --version $VERSION deskreen
         env:
           # First, create a personal access token: (url from Homebrew's output)
-          # https://github.com/settings/tokens/new?scopes=gist,public_repo&description=Homebrew
+          # https://github.com/settings/tokens/new?scopes=gist,public_repo,workflow&description=Homebrew
           # Then, go repo settings -> Secrets -> New repository secret -> HOMEBREW_GITHUB_API_TOKEN : <secret value>.
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
   update-aur:


### PR DESCRIPTION
Now we should add the "workflow" scope into HOMEBREW_GITHUB_API_TOKEN.  
Otherwise, it will go wrong like [pavlobu/deskreen/runs/1942855611?check_suite_focus=true#step:4:210](https://github.com/pavlobu/deskreen/runs/1942855611?check_suite_focus=true#step:4:210).  
Homebrew's changes: [Homebrew/brew/pull/10568](https://github.com/Homebrew/brew/pull/10568)